### PR TITLE
hotfix: disable command logging

### DIFF
--- a/lib/fantasy-irc/plugins.rb
+++ b/lib/fantasy-irc/plugins.rb
@@ -67,7 +67,7 @@ class Plugin
     end
 
     def handle! command, data, args=[]
-        puts "trying to handle #{command} with #{data} and #{args}"
+        #puts "trying to handle #{command} with #{data} and #{args}"
         @handlers.each do |pattern, block|
             if command.match(pattern) then
                 puts "#{block} handles #{command}"


### PR DESCRIPTION
ruby 2.3 handles this with a full printout of the data object. could be fine tuned some day. i had to turn it off as it totally obfuscates the stdout.